### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
     </build>
   <!-- Package as an executable jar -->
 


### PR DESCRIPTION
Para poder desplegar en Heroku, es necesario usar el plugin de spring boot para poder incluir las librerias y clases necesarias para poder ejecutar el jar.